### PR TITLE
Redirect to /errors on load and fix css bug on mobile

### DIFF
--- a/src/app/pages/index.page.ts
+++ b/src/app/pages/index.page.ts
@@ -1,22 +1,6 @@
-import { RouteMeta } from '@analogjs/router';
-import { Component } from '@angular/core';
-import { RouterLink } from '@angular/router';
+import { RedirectRouteMeta } from '@analogjs/router/lib/models';
 
-export const routeMeta: RouteMeta = {
-  title: 'Angular Errors',
+export const routeMeta: RedirectRouteMeta = {
+  redirectTo: '/errors',
+  pathMatch: 'full',
 };
-
-@Component({
-  selector: 'app-home',
-  standalone: true,
-  template: `
-    <div class="flex pl-16 pt-16">
-      <h1 class="md:text-5xl text-3xl font-bold">Angular Errors</h1>
-    </div>
-  `,
-  host: {
-    class: 'flex flex-1 ',
-  },
-  imports: [RouterLink],
-})
-export default class HomeComponent {}

--- a/src/styles.css
+++ b/src/styles.css
@@ -7,3 +7,7 @@
 @tailwind utilities;
 
 /* You can add global styles to this file, and also import other style files */
+
+.analog-markdown li a {
+  word-break: break-all;
+}


### PR DESCRIPTION
- I recall we had said we should probably just redirect to `/errors` on app load. I'm I right?
